### PR TITLE
Fix error not able to import from plugin folder inside the plugin

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+basedirectory = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(basedirectory)
+
 # -*- coding: utf-8 -*-
 
 

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "Flow.Launcher.Plugin.DirectTranslate",
     "Description": "Translate between any languages supported by Googletrans",
     "Author": "Drimix20",
-    "Version": "2.0.0",
+    "Version": "2.0.1",
     "Language": "python",
     "Website": "https://github.com/Drimix20/Flow.Launcher.Plugin.DirectTranslate",
     "IcoPath": "assets/favicon.ico",


### PR DESCRIPTION
Fix error not able to import from plugin folder inside the plugin:

With release 2.0.0 it's not able to import from the plugin folder inside the plugin. There is potentially an issue with the PythonTemplate used in the CI to insert the path into sys.path for using the lib folder, but not including the plugin folder. Until that's fixed, this pr should fix the current issue for now.

Close https://github.com/Drimix20/Flow.Launcher.Plugin.DirectTranslate/issues/8